### PR TITLE
Reboot servers

### DIFF
--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
             o.banner = "Usage: vagrant orchestrate push"
             o.separator ""
 
-            o.on("--reboot", "Reboot a managed server") do
+            o.on("--reboot", "Reboot a managed server after the provisioning step") do
               options[:reboot] = true
             end
           end

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -13,6 +13,10 @@ module VagrantPlugins
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant orchestrate push"
             o.separator ""
+
+            o.on("--reboot", "Reboot a managed server") do
+              options[:reboot] = true
+            end
           end
 
           # Parse the options
@@ -26,6 +30,7 @@ module VagrantPlugins
 
             machine.action(:up, options)
             machine.action(:provision, options)
+            machine.action(:reload, options) if options[:reboot]
             machine.action(:destroy, options)
           end
         end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end


### PR DESCRIPTION
With the newly released version of VMS, the  reload action will reboot a managed server. This pull request allows a vorchestrator to run `vagrant orchestrate push --reboot` and their managed servers will be rebooted after provision. 