### PR TITLE
Init command should put files for puppet provider in puppet directory

### DIFF
--- a/lib/vagrant-orchestrate/command/init.rb
+++ b/lib/vagrant-orchestrate/command/init.rb
@@ -115,9 +115,9 @@ module VagrantPlugins
             if options[:puppet_hiera]
               contents = TemplateRenderer.render(Orchestrate.source_root.join("templates/puppet/hiera.yaml"))
               write_file(File.join("puppet", "hiera.yaml"), contents, options)
-              FileUtils.mkdir_p(File.join(@env.cwd, "puppet", "hiera"))
+              FileUtils.mkdir_p(File.join(@env.cwd, "puppet", "hieradata"))
               contents = TemplateRenderer.render(Orchestrate.source_root.join("templates/puppet/hiera/common.yaml"))
-              write_file(File.join(@env.cwd, "puppet", "hiera", "common.yaml"), contents, options)
+              write_file(File.join(@env.cwd, "puppet", "hieradata", "common.yaml"), contents, options)
             end
 
             FileUtils.mkdir_p(File.join(@env.cwd, "puppet", "manifests"))

--- a/spec/vagrant-orchestrate/command/init_spec.rb
+++ b/spec/vagrant-orchestrate/command/init_spec.rb
@@ -144,8 +144,20 @@ describe VagrantPlugins::Orchestrate::Command::Init do
       it "creates the file" do
         subject.execute
         expect(Dir.entries(File.join(iso_env.cwd, "puppet"))).to include("hiera.yaml")
-        expect(Dir.entries(File.join(iso_env.cwd, "puppet"))).to include("hiera")
-        expect(Dir.entries(File.join(iso_env.cwd, "puppet", "hiera"))).to include("common.yaml")
+        expect(Dir.entries(File.join(iso_env.cwd, "puppet"))).to include("hieradata")
+        expect(Dir.entries(File.join(iso_env.cwd, "puppet", "hieradata"))).to include("common.yaml")
+      end
+
+      describe "hiera.yaml" do
+        it "declares a datadir contains a common.yaml file" do
+          subject.execute
+          hiera_obj = YAML.load(File.read(File.join(iso_env.cwd, "puppet", "hiera.yaml")))
+          datadir = hiera_obj[:datadir]
+          expect(datadir).to start_with("/vagrant")
+          datadir_path = File.join(iso_env.cwd, datadir.sub("/vagrant/", ""))
+          expect(datadir_path).to satisfy { |path| Dir.exist?(path) }
+          expect(Dir.entries(datadir_path)).to include("common.yaml")
+        end
       end
     end
   end

--- a/templates/puppet/hiera.yaml.erb
+++ b/templates/puppet/hiera.yaml.erb
@@ -7,4 +7,4 @@
 - "common"
 
 :yaml:
-:datadir: '/vagrant/puppet/hiera'
+:datadir: '/vagrant/puppet/hieradata'

--- a/templates/puppet/hiera.yaml.erb
+++ b/templates/puppet/hiera.yaml.erb
@@ -7,4 +7,4 @@
 - "common"
 
 :yaml:
-:datadir: '/vagrant/hiera'
+:datadir: '/vagrant/puppet/hiera'


### PR DESCRIPTION
Generate files for the optional puppet provider inside the /puppet directory when running the init command
