### PR TITLE
Made :datadir a child element of the :yaml element in hiera.yaml

### DIFF
--- a/spec/vagrant-orchestrate/command/init_spec.rb
+++ b/spec/vagrant-orchestrate/command/init_spec.rb
@@ -152,7 +152,7 @@ describe VagrantPlugins::Orchestrate::Command::Init do
         it "declares a datadir contains a common.yaml file" do
           subject.execute
           hiera_obj = YAML.load(File.read(File.join(iso_env.cwd, "puppet", "hiera.yaml")))
-          datadir = hiera_obj[:datadir]
+          datadir = hiera_obj[:yaml][:datadir]
           expect(datadir).to start_with("/vagrant")
           datadir_path = File.join(iso_env.cwd, datadir.sub("/vagrant/", ""))
           expect(datadir_path).to satisfy { |path| Dir.exist?(path) }

--- a/templates/puppet/hiera.yaml.erb
+++ b/templates/puppet/hiera.yaml.erb
@@ -7,4 +7,4 @@
 - "common"
 
 :yaml:
-:datadir: '/vagrant/puppet/hieradata'
+  :datadir: '/vagrant/puppet/hieradata'


### PR DESCRIPTION
Make :datadir a child element of the :yaml element in hiera.yaml
This is the structure that hiera looks when using the yaml backend
https://docs.puppetlabs.com/hiera/1/configuring.html#backends