### PR TITLE
Add environment support based on git branch name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 /.vagrant/
 Vagrantfile
 .DS_Store
+servers.json

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ StringLiterals:
 
 Style/FileName:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 100

--- a/lib/vagrant-orchestrate/command/init.rb
+++ b/lib/vagrant-orchestrate/command/init.rb
@@ -95,7 +95,7 @@ module VagrantPlugins
               options[:servers] = list
             end
 
-            o.on("--environments x,y,z", Array, "A CSV list of environments. Take precedence over --servers") do |list|
+            o.on("--environments x,y,z", Array, "A CSV list of environments. Takes precedence over --servers") do |list|
               options[:environments] = list
             end
 

--- a/lib/vagrant-orchestrate/plugin.rb
+++ b/lib/vagrant-orchestrate/plugin.rb
@@ -76,11 +76,53 @@ module VagrantPlugins
 
         # Set the logging level on all "vagrant" namespaced
         # logs as long as we have a valid level.
-        if level
-          Log4r::Logger.new("vagrant_orchestrate").tap do |logger|
-            logger.outputters = Log4r::Outputter.stderr
-            logger.level = level
+        @logger = Log4r::Logger.new("vagrant_orchestrate").tap do |logger|
+          logger.outputters = Log4r::Outputter.stderr
+          logger.level = level || 6
+        end
+      end
+
+      def self.read_git_branch
+        @logger.debug("Reading git branch")
+        if ENV["GIT_BRANCH"]
+          git_branch = ENV["GIT_BRANCH"]
+          @logger.debug("Read git branch #{git_branch} from GIT_BRANCH environment variable")
+        else
+          command = "git rev-parse --abbrev-ref HEAD"
+          git_branch = `#{command}`.chomp
+          if git_branch.include? "fatal"
+            @logger.error("Unable to determine git branch `#{command}`. Is this a git repo?")
+            git_branch = nil
+          else
+            @logger.debug("Read git branch #{git_branch} using `#{command}`")
           end
+        end
+        git_branch
+      end
+
+      def self.load_servers_for_branch
+        setup_logging
+
+        git_branch = read_git_branch
+        return [] if git_branch.nil?
+
+        begin
+          fail "servers.json not found" unless File.exist?("servers.json")
+          @logger.debug("Reading servers.json")
+          contents = IO.read("servers.json")
+          @logger.debug("Read servers.json:\n: #{contents}")
+
+          environments = JSON.parse(contents)["environments"]
+          if environments.key? git_branch
+            return environments[git_branch]["servers"]
+          else
+            @logger.info("No environment found for #{git_branch}, no servers loaded.")
+            return []
+          end
+        rescue StandardError => ex
+          # Don't break the user's whole vagrantfile if we can't load the environment
+          @logger.error(ex.message)
+          return []
         end
       end
     end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/vagrant-orchestrate/command/init_spec.rb
+++ b/spec/vagrant-orchestrate/command/init_spec.rb
@@ -277,6 +277,24 @@ describe VagrantPlugins::Orchestrate::Command::Init do
     end
   end
 
+  context "environments" do
+    let(:argv) { ["--environments", "a,b,c"] }
+    describe "vagrantfile" do
+      it "should contain the loading code" do
+        subject.execute
+        vagrantfile = File.readlines(File.join(iso_env.cwd, "Vagrantfile")).join
+        expect(vagrantfile).to include("managed_servers = VagrantPlugins::Orchestrate::Plugin.load_servers_for_branch")
+      end
+    end
+
+    describe "servers.json" do
+      it "should exist in the target directory" do
+        subject.execute
+        expect(Dir.entries(iso_env.cwd)).to include("servers.json")
+      end
+    end
+  end
+
   context "box" do
     describe "dummy.box" do
       it "winds up in the target directory" do

--- a/templates/environment/servers.json.erb
+++ b/templates/environment/servers.json.erb
@@ -6,6 +6,6 @@
 
       ]
     }<% if index < environments.length - 1 -%>,<% end -%>
-		<% end -%>
+    <% end -%>
   }
 }

--- a/templates/environment/servers.json.erb
+++ b/templates/environment/servers.json.erb
@@ -1,0 +1,11 @@
+{
+  "environments": {
+    <% environments.each_with_index do |environment, index| -%>
+    "<%= environment %>": {
+      "servers": [
+
+      ]
+    }<% if index < environments.length - 1 -%>,<% end -%>
+		<% end -%>
+  }
+}

--- a/templates/vagrant/Vagrantfile.erb
+++ b/templates/vagrant/Vagrantfile.erb
@@ -1,4 +1,8 @@
+<% if environments.any? -%>
+managed_servers = VagrantPlugins::Orchestrate::Plugin.load_servers_for_branch
+<% else -%>
 managed_servers = %w( <% servers.each do |s| -%><%= s %> <% end -%>)
+<% end -%>
 
 <% if plugins.any? -%>
 required_plugins = %w( <% plugins.each do |p| -%><%= p %> <% end -%>)


### PR DESCRIPTION
This adds a --environments command line parameter to the init command This creates a servers.json file that lists the servers for each environment. The current git branch name will be used to determine which servers to load and a branch that has no matching entry in the servers.json file will return an empty list (as in the case of a feature branch). See the readme for more detailed information

--environments will take precedence over --servers.

If not passed, a flat list of servers will be used.