### PR TITLE
Add deployment strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,16 @@ modules/
 For a full list of init options, run `vagrant orchestrate init --help`
 
 ### Pushing changes
-Go ahead and push changes to your managed servers, one at a time. Support for parallel deployments is planned.
+Go ahead and push changes to your managed servers, in serial by default.
 
     $ vagrant orchestrate push
 
-The push command is currently limited by convention to vagrant machines that start with the "managed-" prefix. So if you have other, local machines defined in the Vagrantfile, `vagrant orchestrate push` will not operate on those, but be cautioned that `vagrant up`, `provision` and `destroy` will by default.
+The push command is currently limited by convention to vagrant machines that use the `:managed` provider. So if you have other, local machines defined in the Vagrantfile, `vagrant orchestrate push` will not operate on those.
+
+#### Parallel
+You can push changes to all of your servers in parallel with
+
+    $ vagrant orchestrate push --parallel
 
 You can run vagrant with increased verbosity if you run into problems
 

--- a/README.md
+++ b/README.md
@@ -260,14 +260,14 @@ Go ahead and push changes to your managed servers, in serial by default.
 
 The push command is currently limited by convention to vagrant machines that use the `:managed` provider. So if you have other, local machines defined in the Vagrantfile, `vagrant orchestrate push` will not operate on those.
 
-#### Parallel
+#### Deployment Strategy
+
+Vagrant Orchestrate supports several deployment [strategies](docs/strategies.md), including parallel and
+blue-green.
+
 You can push changes to all of your servers in parallel with
 
-    $ vagrant orchestrate push --parallel
-
-You can run vagrant with increased verbosity if you run into problems
-
-    $ vagrant orchestrate push --debug
+    $ vagrant orchestrate push --strategy parallel
 
 ## Filtering managed commands
 It can be easy to make mistakes such as rebooting production if you have managed long-lived servers as well as local VMs defined in your Vagrantfile. We add some protection with the `orchestrate.filter_managed_commands` configuration setting, which will cause up, provision, reload, and destroy commands to be ignored for servers with the managed provider.

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,4 @@ RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
 task build: ["rubocop:auto_correct", :spec]
+task default: :build

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,0 +1,91 @@
+# Deployment Strategies
+
+Vagrant Orchestrate supports several deployment strategies, including parallel and
+blue-green. Here we'll cover how to use the various strategies as well as describing
+situations when each might be useful.
+
+## Specifying a strategy
+
+### Command line
+
+Strategies can be passed on the command line with the `--strategy` parameter
+
+    $ vagrant orchestrate push --strategy parallel
+
+### Vagrantfile configuration
+
+Alternatively, you can specify the deployment strategy in your Vagrantfile
+
+    config.orchestrate.strategy = :parallel
+
+Command line parameters take precedence over Vagrantfile set configuration values.
+
+## Strategies
+
+### Serial (default)
+This will deploy to the target servers one at a time. This can be useful if you
+have a small number servers, or if you need to keep the majority of your servers
+online in order to support your application's load.
+
+    $ vagrant orchestrate push --strategy serial
+
+    config.orchestrate.strategy = :serial
+
+
+### Parallel
+This strategy will deploy to all of the target servers at the same time. This is
+useful if you want to minimize the amount of time that an overall deployment takes.
+Depending on how you've written your provisioners, this could cause downtime for
+the application that is being deployed.
+
+    $ vagrant orchestrate push --strategy parallel
+
+    config.orchestrate.strategy = :parallel
+
+### Canary
+The canary strategy will deploy to a single server, provide an opportunity to
+test the deployed server, and then deploy the remainder of the servers in parallel.
+This is a great opportunity to test one node of your cluster before blasting your
+changes out to them all. This can be particularly useful when combined with post
+provision [trigger](https://github.com/emyl/vagrant-triggers) to run a smoke test.
+
+    $ vagrant orchestrate push --strategy canary
+
+    config.orchestrate.strategy = :canary
+
+### Blue Green
+The [Blue Green](http://martinfowler.com/bliki/BlueGreenDeployment.html) deployment
+strategy deploys to half of the cluster in parallel, then the other half, with
+a pause in between. This doesn't manage any of your load balancing or networking
+configuraiton for you, but if your application has a healthcheck that your load
+balancer respects, it should be easy to turn it off at the start of your provisioning
+and back on at the end. If your application can serve the load on half of its nodes
+then this will be the best blend of getting the deployment done quickly and maintaining
+a working application.
+
+    $ vagrant orchestrate push --strategy blue_green
+
+    config.orchestrate.strategy = :blue_green
+
+### Canary Blue Green
+This strategy simply combines the two immediately above - deploying to a single
+server, pausing, then to half the cluster in parallel, pausing, and then the remainder,
+also in parallel. Good if you have a large number of servers and want to do a
+smoke test of a single server before committing to pushing to half of your farm.
+
+    $ vagrant orchestrate push --strategy canary_blue_green
+
+		config.orchestrate.strategy = :canary_blue_green
+
+## Suppressing Prompts
+In order to automate the deployment process, it can be very useful to suppress
+prompts. You can achieve that in two ways:
+
+From the command line, add the `--force` or `-f` parameter
+
+    $ vagrant orchestrate push --strategy canary -f
+
+
+Within your vagrantfile, set the `force_push` setting to true
+
+    config.orchestrate.force_push = true

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
               options[:reboot] = true
             end
 
-            o.on("--strategy STRATEGY", "The deployment strategy to use. Default is serial") do |v|
+            o.on("--strategy strategy", "The deployment strategy to use. Default is serial") do |v|
               options[:strategy] = v
             end
 

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -1,6 +1,14 @@
 require "optparse"
 require "vagrant"
 
+class Array
+  def in_groups(num_groups)
+    return [] if num_groups == 0
+    slice_size = (self.size/Float(num_groups)).ceil
+    self.each_slice(slice_size).to_a
+  end
+end
+
 module VagrantPlugins
   module Orchestrate
     module Command
@@ -20,8 +28,8 @@ module VagrantPlugins
               options[:reboot] = true
             end
 
-            o.on("--[no-]parallel", "Execute machine provisioning in parallel. Default is false") do |v|
-              options[:parallel] = v
+            o.on("--strategy STRATEGY", "The deployment strategy to use. Default is serial") do |v|
+              options[:strategy] = v
             end
           end
 
@@ -34,23 +42,62 @@ module VagrantPlugins
             machines << machine if machine.provider_name.to_sym == :managed
           end
 
+          if machines.empty?
+            @env.ui.info("No servers with :managed provider found. Skipping.")
+            return
+          end
+
           # This environment variable is used as a signal to the filtermanaged
           # action so that we don't filter managed commands that are really just
           # the implementation of a push action.
-          ENV["VAGRANT_ORCHESTRATE_COMMAND"] = "PUSH"
-          begin
-            # TODO: This could be moved to a composite "push" action, so that
-            # we could just batchify one action, rather than trying to do this dance.
-            # As written, all of the provisioning would finish before all of the
-            # servers rebooted at the same time.
-            batchify(machines, :up, options)
-            batchify(machines, :provision, options)
-            batchify(machines, :reload, options) if options[:reboot]
-            batchify(machines, :destroy, options)
-          ensure
-            ENV.delete "VAGRANT_ORCHESTRATE_COMMAND"
+
+          options[:parallel] = true
+          strategy = options[:strategy] || machines.first.config.orchestrate.strategy
+          @env.ui.info("Pushing to managed servers using #{strategy} strategy.")
+          case strategy.to_sym
+          when :serial
+            options[:parallel] = false
+            deploy(options, machines)
+          when :parallel
+            deploy(options, machines)
+          when :canary
+            # A single canary server and then the rest
+            deploy(options, machines.take(1), machines.drop(1))
+          when :blue_green
+            # Split into two (almost) equal groups
+            groups = machines.in_groups(2)
+            deploy(options, groups.first, groups.last)
+          when :canary_blue_green
+            # A single canary and then two equal groups
+            canary = machines.take(1)
+            groups = machines.drop(1).in_groups(2)
+            deploy(options, canary, groups.first, groups.last)
+          else
+            @env.ui.error("Invalid deployment strategy specified")
+            return 1
           end
         end
+
+        def deploy(options, *groups)
+          groups.each_with_index do |machines, index|
+            ENV["VAGRANT_ORCHESTRATE_COMMAND"] = "PUSH"
+            begin
+              # TODO: This could be moved to a composite "push" action, so that
+              # we could just batchify one action, rather than trying to do this dance.
+              # As written, all of the provisioning would finish before all of the
+              # servers rebooted at the same time.
+              batchify(machines, :up, options)
+              batchify(machines, :provision, options)
+              batchify(machines, :reload, options) if options[:reboot]
+              batchify(machines, :destroy, options)
+            ensure
+              ENV.delete "VAGRANT_ORCHESTRATE_COMMAND"
+            end
+
+            # TODO: Prompt
+          end
+        end
+
         # rubocop:enable MethodLength
 
         def batchify(machines, action, options)

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -7,8 +7,10 @@ module VagrantPlugins
       class Push < Vagrant.plugin("2", :command)
         include Vagrant::Util
 
+        # rubocop:disable MethodLength
         def execute
           options = {}
+          options[:parallel] = false
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant orchestrate push"
@@ -17,29 +19,45 @@ module VagrantPlugins
             o.on("--reboot", "Reboot a managed server after the provisioning step") do
               options[:reboot] = true
             end
+
+            o.on("--[no-]parallel", "Execution machine provisioning in parallel. Default is false") do |v|
+              options[:parallel] = v
+            end
           end
 
           # Parse the options
           argv = parse_options(opts)
+          return unless argv
 
+          machines = []
           with_target_vms(argv) do |machine|
-            unless machine.provider_name.to_sym == :managed
-              @env.ui.info("Skipping machine #{machine.name}")
-              next
-            end
-            push(machine, options)
+            machines << machine if machine.provider_name.to_sym == :managed
           end
-        end
 
-        def push(machine, options)
+          # This environment variable is used as a signal to the filtermanaged
+          # action so that we don't filter managed commands that are really just
+          # the implementation of a push action.
           ENV["VAGRANT_ORCHESTRATE_COMMAND"] = "PUSH"
           begin
-            machine.action(:up, options)
-            machine.action(:provision, options)
-            machine.action(:reload, options) if options[:reboot]
-            machine.action(:destroy, options)
+            # TODO: This could be moved to a composite "push" action, so that
+            # we could just batchify one action, rather than trying to do this dance.
+            # As written, all of the provisioning would finish before all of the
+            # servers rebooted at the same time.
+            batchify(machines, :up, options)
+            batchify(machines, :provision, options)
+            batchify(machines, :reload, options) if options[:reboot]
+            batchify(machines, :destroy, options)
           ensure
             ENV.delete "VAGRANT_ORCHESTRATE_COMMAND"
+          end
+        end
+        # rubocop:enable MethodLength
+
+        def batchify(machines, action, options)
+          @env.batch(options[:parallel]) do |batch|
+            machines.each do |machine|
+              batch.action(machine, action, options)
+            end
           end
         end
       end

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
               options[:reboot] = true
             end
 
-            o.on("--[no-]parallel", "Execution machine provisioning in parallel. Default is false") do |v|
+            o.on("--[no-]parallel", "Execute machine provisioning in parallel. Default is false") do |v|
               options[:parallel] = v
             end
           end

--- a/lib/vagrant-orchestrate/command/root.rb
+++ b/lib/vagrant-orchestrate/command/root.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
     module Command
       class Root < Vagrant.plugin(2, :command)
         def self.synopsis
-          'Orchestrate provsioning of managed servers across environments'
+          "Orchestrate provsioning of managed servers across environments"
         end
 
         def initialize(argv, env)

--- a/lib/vagrant-orchestrate/command/root.rb
+++ b/lib/vagrant-orchestrate/command/root.rb
@@ -6,8 +6,7 @@ module VagrantPlugins
     module Command
       class Root < Vagrant.plugin(2, :command)
         def self.synopsis
-          'Orchestrates provsioning of managed servers. Useful for deploying changes \
-          repeatedly across multiple managed environments'
+          'Orchestrate provsioning of managed servers across environments'
         end
 
         def initialize(argv, env)

--- a/lib/vagrant-orchestrate/config.rb
+++ b/lib/vagrant-orchestrate/config.rb
@@ -5,10 +5,14 @@ module VagrantPlugins
   module Orchestrate
     class Config < Vagrant.plugin(2, :config)
       attr_accessor :filter_managed_commands
+      attr_accessor :strategy
+      attr_accessor :force_push
       attr_accessor :credentials
 
       def initialize
         @filter_managed_commands = UNSET_VALUE
+        @strategy = UNSET_VALUE
+        @force_push = UNSET_VALUE
         @credentials = Credentials.new
       end
 
@@ -34,6 +38,8 @@ module VagrantPlugins
 
       def finalize!
         @filter_managed_commands = false if @filter_managed_commands == UNSET_VALUE
+        @strategy = :serial if @strategy == UNSET_VALUE
+        @force_push = false if @force_push == UNSET_VALUE
         @credentials = nil if @credentials.unset?
         @credentials.finalize! if @credentials
       end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.3.2"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
This adds 5 deployment strategies that can be set either via the command line or through Vagrantfile config. The strategies are fully documented in docs/strategy.md, but I can summarize:

* serial (default) - one at a time
* parallel - all at the same time
* canary - one, pause, the rest in parallel
* blue_green - half, pause, then the rest in parallel
* canary_blue_green - one, pause, half in parallel, pause, the rest in parallel

These can be passed on the command line with `--strategy parallel` or set in the Vagrantfile with `config.orchestrate.strategy = :parallel`.

Prompting can be surpressed via the command line with `-f` or `--force` or in the Vagrantfile with `config.orchestrate.force_push = true`

@maclennann @potashj 