### PR TITLE
Guard clean, status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+0.5.0 (April 22, 2015)
+
+  - Add guard_clean so that a push will fail if there are uncommitted files. Override with VAGRANT_ORCHESTRATE_NO_GUARD_CLEAN
+  - Push a status file including git remote url, ref, user, and date on a successful provision to /var/status/vagrant_orchestrate (c:\programdata\vagrant_orchestrate)
+  - Retrieve status using `vagrant orchestrate status`

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task default: :build
 
 desc "Run acceptance tests with vagrant-spec"
 task :acceptance do
-  puts "Brining up target servers and syncing with NTP"
+  puts "Bringing up target servers and syncing with NTP"
   # Spinning up local servers here, which the managed provider will connect to
   # by IP. See the Vagrantfile in the root of the repo for more info.
   system("vagrant up /local/ --no-provision")

--- a/Rakefile
+++ b/Rakefile
@@ -10,13 +10,13 @@ task default: :build
 
 desc "Run acceptance tests with vagrant-spec"
 task :acceptance do
-  puts "Brining up target servers"
+  puts "Brining up target servers and syncing with NTP"
   # Spinning up local servers here, which the managed provider will connect to
   # by IP. See the Vagrantfile in the root of the repo for more info.
   system("vagrant up /local/ --no-provision")
   # To ensure the ntp sync happens even if the servers are already up
   system("vagrant provision /local/")
-  system("bundle exec vagrant-spec test --components=orchestrate/push orchestrate/prompt")
+  system("bundle exec vagrant-spec test --components=orchestrate/push orchestrate/prompt orchestrate/status")
   puts "Destroying target servers"
   system("vagrant destroy -f /local/")
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 managed_servers = %w( 192.168.10.80 192.168.10.81 192.168.10.82 192.168.10.83)
 
 Vagrant.configure(2) do |config|
+
+  config.orchestrate.filter_managed_commands = true
+
   # These boxes are defined locally to enable acceptance testing. Spinning up
   # real boxes in the vagrant-spec environment was expensive because it ignored
   # the cache and didn't expose a facility to view the vagrant output as it ran.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 managed_servers = %w( 192.168.10.80 192.168.10.81 192.168.10.82 192.168.10.83)
 
 Vagrant.configure(2) do |config|
-
   config.orchestrate.filter_managed_commands = true
 
   # These boxes are defined locally to enable acceptance testing. Spinning up

--- a/acceptance/command/status_spec.rb
+++ b/acceptance/command/status_spec.rb
@@ -1,0 +1,36 @@
+require "vagrant-spec"
+require "vagrant-orchestrate/repo_status"
+
+describe "vagrant orchestrate status", component: "orchestrate/status" do
+  include_context "acceptance"
+
+  TEST_REF = "050bfd9c686b06c292a9614662b0ab1bbf652db3"
+  TEST_REMOTE_ORIGIN_URL = "http://github.com/Cimpress-MCP/vagrant-orchestrate.git"
+
+  before do
+    environment.skeleton("basic")
+  end
+
+  it "handles no status file gracefully" do
+    # Make sure we're starting from a clean slate, rspec order isn't guaranteed.
+    execute("vagrant", "ssh", "-c", "\"rm -rf /var/state/vagrant_orchestrate\" /managed-1/")
+    # All commands are executed against a single machine to reduce variability
+    result = execute("vagrant", "orchestrate", "status", "/managed-1/")
+    expect(result.stdout).to include("Status unavailable.")
+  end
+
+  it "can push and retrieve status" do
+    # Because vagrant-spec executes in a clean tmp folder, it isn't a git repo,
+    # and the normal git commands don't work. We'll inject some test data using
+    # environment variables. See vagrant-orchestrate/repo_status.rb for impl.
+    ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REF"] = TEST_REF
+    ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REMOTE_ORIGIN_URL"] = TEST_REMOTE_ORIGIN_URL
+    result = execute("vagrant", "orchestrate", "push", "/managed-1/")
+    puts result.stdout
+    result = execute("vagrant", "orchestrate", "status", "/managed-1/")
+    status = VagrantPlugins::Orchestrate::RepoStatus.new
+    # Punting on date. Can always add it later if needed
+    expect(result.stdout).to include(status.ref)
+    expect(result.stdout).to include(status.user)
+  end
+end

--- a/acceptance/command/status_spec.rb
+++ b/acceptance/command/status_spec.rb
@@ -26,7 +26,6 @@ describe "vagrant orchestrate status", component: "orchestrate/status" do
     ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REF"] = TEST_REF
     ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REMOTE_ORIGIN_URL"] = TEST_REMOTE_ORIGIN_URL
     result = execute("vagrant", "orchestrate", "push", "/managed-1/")
-    puts result.stdout
     result = execute("vagrant", "orchestrate", "status", "/managed-1/")
     status = VagrantPlugins::Orchestrate::RepoStatus.new
     # Punting on date. Can always add it later if needed

--- a/acceptance/command/status_spec.rb
+++ b/acceptance/command/status_spec.rb
@@ -25,7 +25,7 @@ describe "vagrant orchestrate status", component: "orchestrate/status" do
     # environment variables. See vagrant-orchestrate/repo_status.rb for impl.
     ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REF"] = TEST_REF
     ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REMOTE_ORIGIN_URL"] = TEST_REMOTE_ORIGIN_URL
-    result = execute("vagrant", "orchestrate", "push", "/managed-1/")
+    execute("vagrant", "orchestrate", "push", "/managed-1/")
     result = execute("vagrant", "orchestrate", "status", "/managed-1/")
     status = VagrantPlugins::Orchestrate::RepoStatus.new
     # Punting on date. Can always add it later if needed

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,82 @@
+# Environments
+It is a very common pattern in software development to have separate environments - e.g. dev, test, and prod.
+Vagrant Orchestrate offers a way to manage multiple environments using a combination of a single servers.json
+file and the name of the current git branch to know which the current environment is.
+
+```javascript
+# servers.json
+{
+  "environments": {
+    "dev": {
+      "servers": [
+        "dev.myapp.mydomain.com"
+      ]
+    },
+    "test": {
+      "servers": [
+        "test1.myapp.mydomain.com",
+        "test2.myapp.mydomain.com"
+      ]
+    },
+    "prod": {
+      "servers": [
+        "prod1.myapp.mydomain.com",
+        "prod2.myapp.mydomain.com",
+        "prod3.myapp.mydomain.com"
+      ]
+    }
+  }
+}
+```
+
+Add the following line to the top of your `Vagrantfile`
+
+```ruby
+managed_servers = VagrantPlugins::Orchestrate::Plugin.load_servers_for_branch
+```
+
+If you create git branches named `dev`, `test`, and `prod`, your vagrantfile will become environment aware and
+you'll only be able to see the servers appropriate for that environment.
+
+```
+$ git branch
+* dev
+  test
+  prod
+$ vagrant status
+Current machine states:
+
+local                     not created (virtualbox)
+dev.myapp.mydomain.com    not created (managed)
+
+$ git checkout test
+Switched to branch 'test'
+$ vagrant status
+Current machine states:
+
+local                     not created (virtualbox)
+test1.myapp.mydomain.com  not created (managed)
+test2.myapp.mydomain.com  not created (managed)
+
+$ git checkout prod
+Switched to branch 'prod'
+$ vagrant status
+Current machine states:
+
+local                     not created (virtualbox)
+prod1.myapp.mydomain.com  not created (managed)
+prod2.myapp.mydomain.com  not created (managed)
+prod3.myapp.mydomain.com  not created (managed)
+```
+
+Any branch that doesn't have a matching environment in the servers.json file will
+not list any managed servers.
+
+```
+$ git checkout -b my_feature_branch
+Switched to a new branch 'my_feature_branch'
+$ vagrant status
+Current machine states:
+
+local                     not created (virtualbox)
+```

--- a/docs/puppet.md
+++ b/docs/puppet.md
@@ -1,0 +1,32 @@
+# Puppet
+
+Experimental [puppet templating](docs/puppet.md) support is available as well with the `--puppet` flag and associated options
+
+```ruby
+  required_plugins = %w( vagrant-managed-servers vagrant-librarian-puppet )
+
+  ...
+
+  config.librarian_puppet.placeholder_filename = ".gitignore"
+  config.vm.provision "puppet" do |puppet|
+    puppet.module_path = 'modules'
+    puppet.hiera_config_path = 'hiera.yaml'
+  end
+```
+
+The following files and folders will be placed in the puppet directory
+
+```
+Puppetfile
+Vagrantfile
+dummy.box
+hiera/
+  common.yaml
+hiera.yaml
+manifests/
+  default.pp
+modules/
+  .gitignore
+```
+
+For a full list of init options, run `vagrant orchestrate init --help`

--- a/lib/vagrant-orchestrate/command/command_mixins.rb
+++ b/lib/vagrant-orchestrate/command/command_mixins.rb
@@ -1,0 +1,26 @@
+module VagrantPlugins
+  module Orchestrate
+    module Command
+      module CommandMixins
+        # Given an array of vagrant command line args (e.g. the result of calling
+        # parse_options), filter out unmanaged servers and provide the resulting list.
+        def filter_unmanaged(argv)
+          machines = []
+          with_target_vms(argv) do |machine|
+            if machine.provider_name.to_sym == :managed
+              machines << machine
+            else
+              @logger.debug("Skipping #{machine.name} because it doesn't use the :managed provider")
+            end
+          end
+
+          if machines.empty?
+            @env.ui.info("No servers with :managed provider found. Exiting.")
+          end
+
+          machines
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-orchestrate/command/init.rb
+++ b/lib/vagrant-orchestrate/command/init.rb
@@ -142,7 +142,7 @@ module VagrantPlugins
                                              environments: options[:environments],
                                              plugins: options[:plugins],
                                              creds_prompt: options[:creds_prompt]
-                                             )
+                                            )
           write_file("Vagrantfile", contents, options)
           FileUtils.cp(Orchestrate.source_root.join("templates", "vagrant", "dummy.box"),
                        File.join(@env.cwd, "dummy.box"))

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -111,7 +111,7 @@ module VagrantPlugins
             begin
               batchify(machines, :up, options)
               batchify(machines, :provision, options)
-              upload_status(machines)
+              upload_status_all(machines)
               batchify(machines, :reload, options) if options[:reboot]
             ensure
               batchify(machines, :destroy, options)

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -1,6 +1,8 @@
 require "optparse"
 require "vagrant"
 require "vagrant-orchestrate/action/setcredentials"
+require "vagrant-orchestrate/repo_status"
+require_relative "command_mixins"
 
 # Borrowed from http://stackoverflow.com/questions/12374645/splitting-an-array-into-equal-parts-in-ruby
 class Array
@@ -16,6 +18,7 @@ module VagrantPlugins
     module Command
       class Push < Vagrant.plugin("2", :command)
         include Vagrant::Util
+        include CommandMixins
 
         @logger = Log4r::Logger.new("vagrant_orchestrate::command::push")
 
@@ -46,19 +49,8 @@ module VagrantPlugins
 
           guard_clean unless ENV["VAGRANT_ORCHESTRATE_NO_GUARD_CLEAN"]
 
-          machines = []
-          with_target_vms(argv) do |machine|
-            if machine.provider_name.to_sym == :managed
-              machines << machine
-            else
-              @logger.debug("Skipping #{machine.name} because it doesn't use the :managed provider")
-            end
-          end
-
-          if machines.empty?
-            @env.ui.info("No servers with :managed provider found. Skipping.")
-            return 0
-          end
+          machines = filter_unmanaged(argv)
+          return 0 if machines.empty?
 
           retrieve_creds(machines) if @env.vagrantfile.config.orchestrate.credentials
 
@@ -96,6 +88,7 @@ module VagrantPlugins
           return 1 unless result
           0
         end
+        # rubocop:enable Metrics/AbcSize, MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def split(machines)
           groups = machines.in_groups(2)
@@ -105,6 +98,7 @@ module VagrantPlugins
           groups
         end
 
+        # rubocop:disable Metrics/AbcSize, MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def deploy(options, *groups)
           groups.select! { |g| g.size > 0 }
           groups.each_with_index do |machines, index|
@@ -117,6 +111,7 @@ module VagrantPlugins
             begin
               batchify(machines, :up, options)
               batchify(machines, :provision, options)
+              upload_status(File.join(@env.tmp_path, "vagrant_orchestrate_status"), @status.repo, machines)
               batchify(machines, :reload, options) if options[:reboot]
             ensure
               batchify(machines, :destroy, options)
@@ -161,10 +156,7 @@ module VagrantPlugins
               creds.apply_creds(machine, username, password)
             end
           else
-            @env.ui.warn <<-WARNING
-Vagrant-orchestrate could not gather credentials. \
-Continuing with default credentials."
-            WARNING
+            @env.ui.warn "Vagrant-orchestrate could not gather credentials. Continuing with default credentials."
           end
         end
 
@@ -180,6 +172,25 @@ Continuing with default credentials."
         def committed?
           `git diff-index --quiet --cached HEAD 2>&1`
           $CHILD_STATUS == 0
+        end
+
+        def upload_status(machines)
+          status = RepoStatus.new
+          source = File.write(File.join(@env.tmp_path, "vagrant_orchestrate_status"), status.to_json)
+          machines.each do |machine|
+            destination = status.remote_path(machine.vm.communicator)
+            parent_folder = File.split(destination)[0]
+            machine.communicate.wait_for_ready(5)
+            @logger.debug("Ensuring vagrant_orchestrate status directory exists")
+            machine.communicate.sudo("mkdir -p #{parent_folder}")
+            machine.communicate.sudo("chmod 777 #{parent_folder}")
+            @logger.debug("Uploading vagrant_orchestrate status file")
+            @logger.debug("  source: #{source}")
+            @logger.debug("  dest: #{destination}")
+            machine.communicate.upload(source, destination)
+            @logger.debug("Setting uploaded file world-writable")
+            machine.communicate.sudo("chmod 777 #{destination}")
+          end
         end
       end
     end

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -44,6 +44,8 @@ module VagrantPlugins
           argv = parse_options(opts)
           return unless argv
 
+          guard_clean unless ENV["VAGRANT_ORCHESTRATE_NO_GUARD_CLEAN"]
+
           machines = []
           with_target_vms(argv) do |machine|
             if machine.provider_name.to_sym == :managed
@@ -164,6 +166,20 @@ Vagrant-orchestrate could not gather credentials. \
 Continuing with default credentials."
             WARNING
           end
+        end
+
+        def guard_clean
+          clean? && committed? || abort("ERROR!\nThere are files that need to be committed first.")
+        end
+
+        def clean?
+          `git diff --exit-code 2>&1`
+          $CHILD_STATUS == 0
+        end
+
+        def committed?
+          `git diff-index --quiet --cached HEAD 2>&1`
+          $CHILD_STATUS == 0
         end
       end
     end

--- a/lib/vagrant-orchestrate/command/root.rb
+++ b/lib/vagrant-orchestrate/command/root.rb
@@ -25,6 +25,11 @@ module VagrantPlugins
             require_relative "push"
             Push
           end
+
+          @subcommands.register(:status) do
+            require_relative "status"
+            Status
+          end
         end
 
         def execute
@@ -44,7 +49,6 @@ module VagrantPlugins
         end
 
         # Prints the help out for this command
-        # rubocop:disable Metrics/AbcSize
         def help
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant orchestrate <subcommand> [<args>]"
@@ -66,7 +70,6 @@ module VagrantPlugins
 
           @env.ui.info(opts.help, prefix: false)
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/lib/vagrant-orchestrate/command/status.rb
+++ b/lib/vagrant-orchestrate/command/status.rb
@@ -1,0 +1,69 @@
+require "json"
+require "optparse"
+require "vagrant"
+require "vagrant-orchestrate/repo_status"
+require_relative "command_mixins"
+
+module VagrantPlugins
+  module Orchestrate
+    module Command
+      class Status < Vagrant.plugin("2", :command)
+        include Vagrant::Util
+        include CommandMixins
+
+        @logger = Log4r::Logger.new("vagrant_orchestrate::command::status")
+
+        def execute
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant orchestrate status"
+            o.separator ""
+          end
+
+          argv = parse_options(opts)
+          return unless argv
+
+          machines = filter_unmanaged(argv)
+          return 0 if machines.empty?
+
+          print_status machines
+        end
+
+        def print_status(machines)
+          # There is some detail output fromt he communicator.download that I
+          # don't want to suppress, but I also don't want it to be interspersed
+          # with the actual status information. Let's buffer the status output.
+          output = []
+          @logger.debug("About to download machine status")
+          machines.each do |machine|
+            output << get_status(RepoStatus.new.remote_path(machine.config.vm.communicator), machine)
+          end
+          @env.ui.info("Current managed server states:")
+          @env.ui.info("")
+          output.each do |line|
+            @env.ui.info line
+          end
+        end
+
+        def get_status(remote, machine)
+          machine.communicate.wait_for_ready(5)
+          local = File.join(@env.tmp_path, "#{machine.name}_status")
+          @logger.debug("Downloading orchestrate status for #{machine.name}")
+          @logger.debug("  remote file: #{remote}")
+          @logger.debug("  local file: #{local}")
+          machine.communicate.download(remote, local)
+          content = File.read(local)
+          @logger.debug("File content:")
+          @logger.debug(content)
+          status = JSON.parse(content)
+          return machine.name.to_s + "   " + status["last_sync"] + "  " + status["ref"] + "  " + status["user"]
+        rescue => ex
+          @env.ui.warn("Error downloading status for #{machine.name}.")
+          @env.ui.warn(ex.message)
+          return machine.name.to_s + "   Status unavailable."
+        ensure
+          File.delete(local) if File.exist?(local)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-orchestrate/repo_status.rb
+++ b/lib/vagrant-orchestrate/repo_status.rb
@@ -1,0 +1,61 @@
+require "json"
+
+module VagrantPlugins
+  module Orchestrate
+    class RepoStatus
+      attr_reader :last_sync
+
+      def initialize
+        @last_sync = Time.now.utc    # Managed servers could be in different timezones
+      end
+
+      def ref
+        # Env vars are here only for testing, since vagrant-spec is executed from
+        # a temp directory and can't use git to get repository information
+        @ref ||= ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REF"]
+        @ref ||= `git log --pretty=format:'%H' --abbrev-commit -1`
+        @ref
+      end
+
+      def remote_origin_url
+        @remote_origin_url ||= ENV["VAGRANT_ORCHESTRATE_STATUS_TEST_REMOTE_ORIGIN_URL"]
+        @remote_origin_url ||= `git config --get remote.origin.url`.chomp
+        @remote_origin_url
+      end
+
+      def repo
+        @repo ||= File.basename(remote_origin_url, ".git")
+        @repo
+      end
+
+      def user
+        user = ENV["USER"] || ENV["USERNAME"] || "unknown"
+        user = ENV["USERDOMAIN"] + "\\" + @user if ENV["USERDOMAIN"]
+
+        @user ||= user
+        @user
+      end
+
+      def to_json
+        contents = {
+          repo: repo,
+          remote_url: remote_origin_url,
+          ref: ref,
+          user: user,
+          last_sync: last_sync
+        }
+        JSON.pretty_generate(contents)
+      end
+
+      # The path to where this should be stored on a remote machine, inclusive
+      # of the file name.
+      def remote_path(communicator)
+        if communicator == :winrm
+          File.join("c:", "programdata", "vagrant_orchestrate", repo)
+        else
+          File.join("/var", "state", "vagrant_orchestrate", repo)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.5.0"
+    VERSION = "0.5.0.pre"
   end
 end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.4.7"
+    VERSION = "0.5.0"
   end
 end

--- a/lib/vms.save
+++ b/lib/vms.save
@@ -1,0 +1,24 @@
+# R&D work that may be used in a future version, but can be ignored for now.
+module ManagedServers
+  module Action
+    include Vagrant::Action::Builtin
+    def self.action_push
+      Vagrant::Action::Builder.new.tap do |b|
+        b.use HandleBox
+        b.use ConfigValidate
+        b.use WarnNetworks
+        b.use Call, IsLinked do |env, b2|
+          if env[:result]
+            b2.use MessageAlreadyLinked
+            next
+          end
+
+          b2.use LinkServer
+        end
+        b.use Provision
+        b.use SyncFolders
+        b.use UnlinkServer
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the ability to guard clean (stolen from Bundler), so that all files in your local repository need to be added and committed. 

Add the `vagrant orchestrate status` command, which will print status information about the last push (user, date, ref) for all managed servers. See the docs for a detailed example.

@maclennann @potashj @swivelhinges @cmoore-cimpress 