### PR TITLE
Creds env var fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5.3 (May 13th, 2015)
+
+  - Fix a bug where the VAGRANT_ORCHESTRATE_USERNAME and VAGRANT_ORCHESTRATE_PASSWORD
+  environment variable overrides weren't being read properly. The bug was repro'd
+  on a Windows environment.
+
 0.5.2 (May 8th, 2015)
 
   - Add the `--no-provision` option to the `orchestrate push` command. Useful for

--- a/lib/vagrant-orchestrate/action/setcredentials.rb
+++ b/lib/vagrant-orchestrate/action/setcredentials.rb
@@ -6,8 +6,14 @@ module VagrantPlugins
           return unless config_creds
 
           # Use environment variable overrides, or else what was provided in the config file
-          config_creds.username = ENV["VAGRANT_ORCHESTRATE_USERNAME"] || config_creds.username
-          config_creds.password = ENV["VAGRANT_ORCHESTRATE_PASSWORD"] || config_creds.password
+          if ENV["VAGRANT_ORCHESTRATE_USERNAME"]
+            ui.info("Using VAGRANT_ORCHESTRATE_USERNAME environment variable override")
+            config_creds.username = ENV["VAGRANT_ORCHESTRATE_USERNAME"].dup
+          end
+          if ENV["VAGRANT_ORCHESTRATE_PASSWORD"]
+            ui.info("Using VAGRANT_ORCHESTRATE_PASSWORD environment variable override")
+            config_creds.password = ENV["VAGRANT_ORCHESTRATE_PASSWORD"].dup
+          end
 
           # Use credentials file to any username or password that is still undiscovered
           check_creds_file(config_creds, ui) unless config_creds.username && config_creds.password

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -161,7 +161,7 @@ module VagrantPlugins
             machines.each do |machine|
               creds.apply_creds(machine, username, password)
             end
-          elsif @env.vagrantfile.config.orchestrate.credentials
+          else
             @env.ui.warn "Vagrant-orchestrate did find any credentials. Continuing with default credentials."
           end
         end

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -161,8 +161,8 @@ module VagrantPlugins
             machines.each do |machine|
               creds.apply_creds(machine, username, password)
             end
-          else
-            @env.ui.warn "Vagrant-orchestrate could not gather credentials. Continuing with default credentials."
+          elsif @env.vagrantfile.config.orchestrate.credentials
+            @env.ui.warn "Vagrant-orchestrate did find any credentials. Continuing with default credentials."
           end
         end
 

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end


### PR DESCRIPTION
When the environment variables were being read, we were storing a reference to the ENV hash value, which was later causing deployments to Windows machines to fail, presumably because something was trying to modify the value. By duplicating the environment variables, this prevents it and the deployments succeed.

@maclennann 