### PR TITLE
Action print status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   strategy will truly be parallel per box, as opposed to the old implementation where
   the `up`, `provision`, `upload_stats`, and `destroy` phases would each happen in
   parallel, but the phases would be done in series.
+  - Change the `vagrant orchestrate status` command so that it will run in parallel.
 
 0.5.3 (May 13th, 2015)
 

--- a/lib/vagrant-managed-servers/action.rb
+++ b/lib/vagrant-managed-servers/action.rb
@@ -19,6 +19,13 @@ module VagrantPlugins
           b.use action_destroy
         end
       end
+
+      def self.action_download_status
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use DownloadStatus
+        end
+      end
     end
   end
 end

--- a/lib/vagrant-managed-servers/action/download_status.rb
+++ b/lib/vagrant-managed-servers/action/download_status.rb
@@ -31,8 +31,6 @@ module VagrantPlugins
           ui.warn("Error downloading status for #{machine.name}.")
           ui.warn(ex.message)
           ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   Status unavailable.\n"
-        ensure
-          super_delete(local) if File.exist?(local)
         end
       end
     end

--- a/lib/vagrant-managed-servers/action/download_status.rb
+++ b/lib/vagrant-managed-servers/action/download_status.rb
@@ -1,0 +1,44 @@
+require "log4r"
+
+module VagrantPlugins
+  module ManagedServers
+    module Action
+      class DownloadStatus
+        include Vagrant::Util::Retryable
+
+        def initialize(app, _env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_managed_servers::action::print_status")
+        end
+
+        def call(env)
+          machine = env[:machine]
+          local = env[:local_file_path]
+          remote = env[:remote_file_path]
+          ui = env[:ui]
+
+          begin
+            machine.communicate.wait_for_ready(5)
+            @logger.debug("Downloading orchestrate status for #{machine.name}")
+            @logger.debug("  remote file: #{remote}")
+            @logger.debug("  local file: #{local}")
+            machine.communicate.download(remote, local)
+            content = File.read(local)
+            @logger.debug("File content:")
+            @logger.debug(content)
+            status = JSON.parse(content)
+            ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   " + status["last_sync"] + "  " + status["ref"] + "  " + status["user"] + "\n"
+          rescue => ex
+            ui.warn("Error downloading status for #{machine.name}.")
+            ui.warn(ex.message)
+            ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   Status unavailable.\n"
+          ensure
+            super_delete(local) if File.exist?(local)
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-managed-servers/action/download_status.rb
+++ b/lib/vagrant-managed-servers/action/download_status.rb
@@ -4,39 +4,35 @@ module VagrantPlugins
   module ManagedServers
     module Action
       class DownloadStatus
-        include Vagrant::Util::Retryable
-
         def initialize(app, _env)
           @app    = app
           @logger = Log4r::Logger.new("vagrant_managed_servers::action::print_status")
         end
 
         def call(env)
-          machine = env[:machine]
-          local = env[:local_file_path]
-          remote = env[:remote_file_path]
-          ui = env[:ui]
-
-          begin
-            machine.communicate.wait_for_ready(5)
-            @logger.debug("Downloading orchestrate status for #{machine.name}")
-            @logger.debug("  remote file: #{remote}")
-            @logger.debug("  local file: #{local}")
-            machine.communicate.download(remote, local)
-            content = File.read(local)
-            @logger.debug("File content:")
-            @logger.debug(content)
-            status = JSON.parse(content)
-            ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   " + status["last_sync"] + "  " + status["ref"] + "  " + status["user"] + "\n"
-          rescue => ex
-            ui.warn("Error downloading status for #{machine.name}.")
-            ui.warn(ex.message)
-            ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   Status unavailable.\n"
-          ensure
-            super_delete(local) if File.exist?(local)
-          end
+          download_status(env[:machine], env[:local_file_path], env[:remote_file_path], env[:ui])
 
           @app.call(env)
+        end
+
+        def download_status(machine, local, remote, ui)
+          machine.communicate.wait_for_ready(5)
+          @logger.debug("Downloading orchestrate status for #{machine.name}")
+          @logger.debug("  remote file: #{remote}")
+          @logger.debug("  local file: #{local}")
+          machine.communicate.download(remote, local)
+          content = File.read(local)
+          @logger.debug("File content:")
+          @logger.debug(content)
+          status = JSON.parse(content)
+          ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   " + status["last_sync"] + \
+                                               "  " + status["ref"] + "  " + status["user"] + "\n"
+        rescue => ex
+          ui.warn("Error downloading status for #{machine.name}.")
+          ui.warn(ex.message)
+          ENV["VAGRANT_ORCHESTRATE_STATUS"] += machine.name.to_s + "   Status unavailable.\n"
+        ensure
+          super_delete(local) if File.exist?(local)
         end
       end
     end

--- a/lib/vagrant-managed-servers/action/upload_status.rb
+++ b/lib/vagrant-managed-servers/action/upload_status.rb
@@ -4,8 +4,6 @@ module VagrantPlugins
   module ManagedServers
     module Action
       class UploadStatus
-        include Vagrant::Util::Retryable
-
         def initialize(app, _env)
           @app    = app
           @logger = Log4r::Logger.new("vagrant_managed_servers::action::upload_status")

--- a/lib/vagrant-orchestrate/command/status.rb
+++ b/lib/vagrant-orchestrate/command/status.rb
@@ -38,16 +38,22 @@ module VagrantPlugins
           @logger.debug("About to download machine status")
           options = {}
           parallel = true
+          local_files = []
           @env.batch(parallel) do |batch|
             machines.each do |machine|
               options[:remote_file_path] = RepoStatus.new.remote_path(machine.config.vm.communicator)
               options[:local_file_path] = File.join(@env.tmp_path, "#{machine.name}_status")
+              local_files << options[:local_file_path]
               batch.action(machine, :download_status, options)
             end
           end
           @env.ui.info("Current managed server states:")
           @env.ui.info("")
           @env.ui.info(ENV["VAGRANT_ORCHESTRATE_STATUS"].split("\n").sort.join("\n"))
+        ensure
+          local_files.each do |local|
+            super_delete(local) if File.exist?(local)
+          end
         end
       end
     end


### PR DESCRIPTION
Turn the print status functionality from being executed in serial in the `status` command, to an action that can be run in a batch. 