### PR TITLE
Add vagrant-orchestrate as a required plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   the `up`, `provision`, `upload_stats`, and `destroy` phases would each happen in
   parallel, but the phases would be done in series.
   - Change the `vagrant orchestrate status` command so that it will run in parallel.
+  - Add `vagrant-orchestrate` as a default required plugin. Someone will have to
+  install it "by hand" to access the init functionality, but other users pulling
+  down a repo with a committed Vagrantfile will not, making each repo more self-contained.
 
 0.5.3 (May 13th, 2015)
 

--- a/lib/vagrant-orchestrate/command/init.rb
+++ b/lib/vagrant-orchestrate/command/init.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
         DEFAULT_WINRM_PASSWORD = "{{YOUR_WINRM_PASSWORD}}"
         DEFAULT_SSH_USERNAME = "{{YOUR_SSH_USERNAME}}"
         DEFAULT_SSH_PRIVATE_KEY_PATH = "{{YOUR_SSH_PRIVATE_KEY_PATH}}"
-        DEFAULT_PLUGINS = ["vagrant-managed-servers"]
+        DEFAULT_PLUGINS = ["vagrant-orchestrate", "vagrant-managed-servers"]
 
         # rubocop:disable Metrics/AbcSize, MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def execute


### PR DESCRIPTION
Meant to address #20 and make each repo more self contained, requiring less bootstrapping steps from new users. 

@potashj 