### PR TITLE
Remove the inline patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-0.6.1 (May 18th, 2015)
+0.6.1 (May 23rd, 2015)
 
   - Change the credentials manager to add the `smb_username` and `smb_password` to
   the synced folders for a machine if the communicator is `winrm`. For Windows,
-  this means only a single credential prompt.
+  this means only a single credential prompt for both machine authentication and
+  SMB auth.
 
 0.6.0 (May 15th, 2015)
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ sc config winrm type= own
 ```
 * Check out [the winrm-s readme](https://github.com/Cimpress-MCP/vagrant-winrm-s/blob/master/README.md#setting-up-your-server) for more information
 
+### Synced Folders
+
+See the [Synced Folders](https://github.com/tknerr/vagrant-managed-servers#synced-folders-windows)
+section of the Vagrant Managed Servers readme for more detail.
+
 ## Contributing
 
 1. Fork it ( https://github.com/Cimpress-MCP/vagrant-orchestrate/fork )

--- a/lib/vagrant-managed-servers/action.rb
+++ b/lib/vagrant-managed-servers/action.rb
@@ -26,46 +26,6 @@ module VagrantPlugins
           b.use DownloadStatus
         end
       end
-
-      # !!!!!!!!!!!!!!!!!!!!!! "TEMPORARY" PATCH !!!!!!!!!!!!!!!!!!!!!!!
-      # I'm adding the SMB support here, while I wait on feedback for
-      # https://github.com/tknerr/vagrant-managed-servers/pull/47
-      # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      # This action is called when `vagrant provision` is called.
-      # rubocop:disable MethodLength
-      def self.action_provision
-        Vagrant::Action::Builder.new.tap do |b|
-          b.use ConfigValidate
-          b.use WarnNetworks
-          b.use Call, IsLinked do |env, b2|
-            unless env[:result]
-              b2.use MessageNotLinked
-              next
-            end
-
-            # rubocop:disable Lint/ShadowingOuterLocalVariable
-            b2.use Call, IsReachable do |env, b3|
-              unless env[:result]
-                b3.use MessageNotReachable
-                next
-              end
-
-              b3.use Provision
-              if env[:machine].config.vm.communicator == :winrm
-                # Use the builtin vagrant folder sync for Windows target servers.
-                # This gives us SMB folder sharing, which is much faster than the
-                # WinRM uploader for any non-trivial number of files.
-                b3.use Vagrant::Action::Builtin::SyncedFolders
-              else
-                # Vagrant managed servers custom implementation
-                b3.use SyncFolders
-              end
-            end
-            # rubocop:enable Lint/ShadowingOuterLocalVariable
-          end
-        end
-        # rubocop:enable MethodLength
-      end
     end
   end
 end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.6.1.patch"
+    VERSION = "0.6.1"
   end
 end


### PR DESCRIPTION
now that vagrant-managed-servers has SMB support. Requires vagrant-managed-servers 0.7.1 or greater to be installed.