### PR TITLE
Non git repo

### DIFF
--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,0 +1,22 @@
+required_plugins = {}
+# Example usage:
+# required_plugins["plugin-name"] = { version: "1.2.3", source: "https://rubygems.org" }
+required_plugins["vagrant-orchestrate"] = {}
+required_plugins["vagrant-managed-servers"] = {}
+
+needs_restart = false
+required_plugins.each do |plugin, options|
+  version = options[:version]
+
+  unless Vagrant.has_plugin?(plugin, version)
+    command = "vagrant plugin install #{plugin}"
+    command += " --plugin-version #{version}" if version
+    command += " --plugin-source #{options[:source]}" if options[:source]
+    system command
+    needs_restart = true
+  end
+end
+
+if needs_restart
+  exec "vagrant #{ARGV.join' '}"
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   - Extract the `required_plugins` definition and installation logic from the
   `Vagrantfile` to a new `.vagrantplugins` file per https://github.com/mitchellh/vagrant/issues/4347
   - Change required_plugins from array to hash[plugin-name] = {options}. This allows specifying specific versions of plugins to be installed as well as alternate gem sources, which is useful for internally hosted gems.
+  - Fall back to the Vagrant environment's `root_path` if the working directory is
+  not a git repo. Fixes [#34](https://github.com/Cimpress-MCP/vagrant-orchestrate/issues/34)
 
 0.6.2 (May 25th, 2015)
 

--- a/acceptance/command/status_spec.rb
+++ b/acceptance/command/status_spec.rb
@@ -6,7 +6,7 @@ describe "vagrant orchestrate status", component: "orchestrate/status" do
 
   TEST_REF = "050bfd9c686b06c292a9614662b0ab1bbf652db3"
   TEST_REMOTE_ORIGIN_URL = "http://github.com/Cimpress-MCP/vagrant-orchestrate.git"
-  TEST_REPO = "/users/cbaldauf/dev/vagrant-orchestrate"
+  TEST_REPO = "vagrant-orchestrate"
 
   before do
     environment.skeleton("basic")
@@ -14,7 +14,8 @@ describe "vagrant orchestrate status", component: "orchestrate/status" do
 
   it "handles no status file gracefully" do
     # Make sure we're starting from a clean slate, rspec order isn't guaranteed.
-    execute("vagrant", "ssh", "-c", "\"rm -rf /var/state/vagrant_orchestrate\" managed-1")
+    execute("vagrant", "up", "managed-1")
+    execute("vagrant", "ssh", "-c", "\"sudo rm -rf /var/state/vagrant_orchestrate\"", "managed-1")
     # All commands are executed against a single machine to reduce variability
     result = execute("vagrant", "orchestrate", "status", "/managed-1/")
     expect(result.stdout).to include("Status unavailable.")
@@ -30,7 +31,7 @@ describe "vagrant orchestrate status", component: "orchestrate/status" do
     ENV["VAGRANT_ORCHESTRATE_NO_GUARD_CLEAN"] = "true"
     execute("vagrant", "orchestrate", "push", "/managed-1/")
     result = execute("vagrant", "orchestrate", "status", "/managed-1/")
-    status = VagrantPlugins::Orchestrate::RepoStatus.new
+    status = VagrantPlugins::Orchestrate::RepoStatus.new(TEST_REPO)
     # Punting on date. Can always add it later if needed
     expect(result.stdout).to include(status.ref)
     expect(result.stdout).to include(status.user)

--- a/lib/vagrant-managed-servers/action/download_status.rb
+++ b/lib/vagrant-managed-servers/action/download_status.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
         def download_status(machine, local, remote, ui)
           machine.communicate.wait_for_ready(5)
           @logger.debug("Downloading orchestrate status for #{machine.name}")
+          ui.info("Downloading orchestrate status from #{remote}")
           @logger.debug("  remote file: #{remote}")
           @logger.debug("  local file: #{local}")
           machine.communicate.download(remote, local)

--- a/lib/vagrant-managed-servers/action/upload_status.rb
+++ b/lib/vagrant-managed-servers/action/upload_status.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
           @logger.debug("Ensuring vagrant_orchestrate status directory exists")
           machine.communicate.sudo("mkdir -p #{parent_folder}")
           machine.communicate.sudo("chmod 777 #{parent_folder}")
-          ui.info("Uploading vagrant orchestrate status")
+          ui.info("Uploading vagrant orchestrate status to #{destination}")
           @logger.debug("Uploading vagrant_orchestrate status")
           @logger.debug("  source: #{source}")
           @logger.debug("  dest: #{destination}")

--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
 
           # Write the status file to disk so that it can be used as part of the
           # push action.
-          status = RepoStatus.new
+          status = RepoStatus.new(@env.root_path)
           status.write(@env.tmp_path)
           options[:status] = status
 

--- a/lib/vagrant-orchestrate/command/status.rb
+++ b/lib/vagrant-orchestrate/command/status.rb
@@ -41,14 +41,14 @@ module VagrantPlugins
           local_files = []
           @env.batch(parallel) do |batch|
             machines.each do |machine|
-              options[:remote_file_path] = RepoStatus.new.remote_path(machine.config.vm.communicator)
+              status = RepoStatus.new(@env.root_path)
+              options[:remote_file_path] = status.remote_path(machine.config.vm.communicator)
               options[:local_file_path] = File.join(@env.tmp_path, "#{machine.name}_status")
               local_files << options[:local_file_path]
               batch.action(machine, :download_status, options)
             end
           end
-          @env.ui.info("Current managed server states:")
-          @env.ui.info("")
+          @env.ui.info("Current managed server states:\n")
           @env.ui.info(ENV["VAGRANT_ORCHESTRATE_STATUS"].split("\n").sort.join("\n"))
         ensure
           local_files.each do |local|


### PR DESCRIPTION
Fall back to the Vagrant environment's `root_path` if the working directory is not a git repo. Fixes #34 

@maclennann 