### PR TITLE
Add an action as part of the push command that will change ownership …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,5 +16,8 @@ StringLiterals:
 Style/FileName:
   Enabled: false
 
+Style/RegexpLiteral:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8.0 (Unreleased)
+
+  - Add an action as part of the push command that will change ownership of all synced folders to the configured user to avoid permission conflicts.
+    - Added config.orchestrate.take_synced_file_ownership and documented in docs/config.md (default is true)
+    - Should have no impact on Windows systems, since `chown` is filtered out by the winrm communicator filter
+
 0.7.2 (September 25th, 2015)
 
   - Include windows guest directive on winrm template to correct issues with incorrect

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,3 +9,11 @@ servers if there are any uncommitted or untracked files in your git repository. 
 the `disable_commit_guard` configuration option will disable this protection.
 
     config.orchestrate.disable_commit_guard = true
+
+## `take_synced_folder_ownership`
+
+When multiple users are using Vagrant Orchestrate to push to the same target servers,
+there can arise permission issues for folders that are synced. When `true`, Vagrant
+Orchestrate will change ownership of the guestpath of all synced folders to be the
+`owner` specified in the `synced_folder` or the `ssh_info.username`. Has no affect
+for Windows guests. Default is `true`.

--- a/lib/vagrant-managed-servers/action.rb
+++ b/lib/vagrant-managed-servers/action.rb
@@ -1,5 +1,6 @@
 require "vagrant-managed-servers/action/upload_status"
 require "vagrant-managed-servers/action/init_deployment_tracker"
+require "vagrant-managed-servers/action/take_synced_folder_ownership"
 require "vagrant-managed-servers/action/track_deployment_start"
 require "vagrant-managed-servers/action/track_deployment_end"
 require "vagrant-managed-servers/action/track_server_deployment_start"
@@ -17,6 +18,7 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use TrackServerDeploymentStart
           b.use action_up
+          b.use TakeSyncedFolderOwnership
           b.use Call, action_provision do |env, b2|
             if env[:reboot]
               b2.use Call, action_reload do |_env, _b3|

--- a/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
+++ b/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
@@ -1,0 +1,34 @@
+require "log4r"
+
+module VagrantPlugins
+  module ManagedServers
+    module Action
+      class TakeSyncedFolderOwnership
+        def initialize(app, _env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_managed_servers::action::take_synced_folder_ownership")
+        end
+
+        def call(env)
+          take_synced_folder_ownership env[:machine], env[:ui]
+          @app.call(env)
+        end
+
+        def take_synced_folder_ownership(machine, ui)
+          return unless machine.config.orchestrate.take_synced_folder_ownership
+          ui.info "Taking ownership of all guest synced folders"
+
+          machine.config.vm.synced_folders.each do |synced_folder|
+            name = synced_folder[0]
+            options = synced_folder[1]
+            next if options[:disabled]
+            options[:owner] ||= machine.ssh_info[:username]
+            @logger.debug "Taking ownership of #{name}"
+            @logger.debug options
+            machine.communicate.sudo "chown #{options[:owner]} -R #{options[:guestpath]}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
+++ b/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             options[:owner] ||= machine.ssh_info[:username]
             @logger.debug "Taking ownership of #{name}"
             @logger.debug options
-            machine.communicate.sudo "chown #{options[:owner]} -R #{options[:guestpath]}"
+            machine.communicate.sudo "chown '#{options[:owner]}' -R #{options[:guestpath]}"
           end
         end
       end

--- a/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
+++ b/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
@@ -20,7 +20,6 @@ module VagrantPlugins
 
           @logger.debug "Taking ownership of synced folders"
           machine.config.vm.synced_folders.each do |synced_folder|
-            name = synced_folder[0]
             options = synced_folder[1]
             next if options[:disabled]
             options[:owner] ||= machine.ssh_info[:username]

--- a/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
+++ b/lib/vagrant-managed-servers/action/take_synced_folder_ownership.rb
@@ -18,15 +18,26 @@ module VagrantPlugins
           return unless machine.config.orchestrate.take_synced_folder_ownership
           ui.info "Taking ownership of all guest synced folders"
 
+          @logger.debug "Taking ownership of synced folders"
           machine.config.vm.synced_folders.each do |synced_folder|
             name = synced_folder[0]
             options = synced_folder[1]
             next if options[:disabled]
             options[:owner] ||= machine.ssh_info[:username]
-            @logger.debug "Taking ownership of #{name}"
-            @logger.debug options
-            machine.communicate.sudo "chown '#{options[:owner]}' -R #{options[:guestpath]}"
+            chown machine, options[:guestpath], options[:owner]
           end
+
+          @logger.debug "Taking ownership of provisioner assets"
+          machine.config.vm.provisioners.each do |provisioner|
+            owner = machine.ssh_info[:username]
+            chown machine, provisioner.config.upload_path, owner if provisioner.type == :shell
+            chown machine, provisioner.config.temp_dir, owner if provisioner.type == :puppet
+          end
+        end
+
+        def chown(machine, path, owner)
+          @logger.debug "Taking ownership of #{path}"
+          machine.communicate.sudo "chown '#{owner}' -R #{path}"
         end
       end
     end

--- a/lib/vagrant-orchestrate/config.rb
+++ b/lib/vagrant-orchestrate/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :tracker_logging_enabled
       attr_accessor :credentials
       attr_accessor :disable_commit_guard
+      attr_accessor :take_synced_folder_ownership
 
       def initialize
         @filter_managed_commands = UNSET_VALUE
@@ -19,6 +20,7 @@ module VagrantPlugins
         @tracker_host = UNSET_VALUE
         @tracker_logging_enabled = UNSET_VALUE
         @disable_commit_guard = UNSET_VALUE
+        @take_synced_folder_ownership = UNSET_VALUE
         @credentials = Credentials.new
       end
 
@@ -50,6 +52,7 @@ module VagrantPlugins
         @tracker_host = nil if @tracker_host == UNSET_VALUE
         @tracker_logging_enabled = true if @tracker_logging_enabled == UNSET_VALUE
         @disable_commit_guard = false if @disable_commit_guard == UNSET_VALUE
+        @take_synced_folder_ownership = true if @take_synced_folder_ownership == UNSET_VALUE
         @credentials = nil if @credentials.unset?
         @credentials.finalize! if @credentials
       end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.8.0.pre.2"
+    VERSION = "0.8.0.pre.3"
   end
 end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.8.0.pre.1"
+    VERSION = "0.8.0.pre.2"
   end
 end

--- a/lib/vagrant-orchestrate/version.rb
+++ b/lib/vagrant-orchestrate/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Orchestrate
-    VERSION = "0.7.2"
+    VERSION = "0.8.0.pre.1"
   end
 end


### PR DESCRIPTION
…of all synced folders tothe configured user to avoid permission conflicts.

- Added config.orchestrate.take_synced_file_ownership and docuented in docs/config.md (default is true)
- Should have no impact on Windows systems, since `chown` is filtered out by the winrm communicator filter
- version bump to 0.8.0
- Slight config change to make rubocop happy

/cc @maclennann @am17torres @swivelhinges @potashj