### PR TITLE
Swapping order of half_half strategy to ensure maximum uptime

### DIFF
--- a/lib/vagrant-orchestrate/command/push.rb
+++ b/lib/vagrant-orchestrate/command/push.rb
@@ -99,14 +99,14 @@ module VagrantPlugins
               # A single canary server and then the rest
               result = deploy(options, machines.take(1), machines.drop(1))
             when :half_half
-              # Split into two (almost) equal groups
+              # Split into two (almost) equal groups - start with the second group in case this is the first deployment to new instances
               groups = split(machines)
-              result = deploy(options, groups.first, groups.last)
+              result = deploy(options, groups.last, groups.first)
             when :canary_half_half
-              # A single canary and then two equal groups
+              # A single canary and then two equal groups - start with the second group in case this is the first deployment to new instances
               canary = machines.take(1)
               groups = split(machines.drop(1))
-              result = deploy(options, canary, groups.first, groups.last)
+              result = deploy(options, canary, groups.last, groups.first)
             else
               @env.ui.error("Invalid deployment strategy specified")
               result = false


### PR DESCRIPTION
Use case: we have 2 machines running a service, we want to add 2 more. We create the instances and then re-run the deployment task to push to the added instances. Instances 1 and 2 are deployed first, but since they are the only ones actually running the service, the deployment can cause a brief outage while the service restarts. If we deploy to the back half first, we can avoid this problem.